### PR TITLE
Tunnel trafikkmengde

### DIFF
--- a/README
+++ b/README
@@ -2,11 +2,17 @@ Et verktøyskriv med klasser, funksjoner og script som benytter data fra
 Nasjonal vegdatabank (NVDB) API: https://www.vegvesen.no/nvdb/api/
 
 nvdb.py:
-Modul med grunnleggende klasser og funksjoner.
+Modul med grunnleggende klasser og funksjoner. 
 
 tunneler_med_ulykker.py:
 Script som finner alle trafikkulykker som har skjedd inne i tunneler, og 
 summerer dem sammen i en csv-fil. En rad per tunnel. Er avhengig av nvdb.py. 
+Vær oppmerksom på at spørringer med veglenker som geografisk lokasjon, tar 
+lang tid sammenlignet med andre spørringer mot APIet.
+
+tunneler_med_trafikkmengde.py:
+Script som finner trafikkmengde per tunnelløp, og 
+summerer dem sammen i en csv-fil. En rad per tunnelløp. Er avhengig av nvdb.py. 
 Vær oppmerksom på at spørringer med veglenker som geografisk lokasjon, tar 
 lang tid sammenlignet med andre spørringer mot APIet.
 
@@ -22,6 +28,9 @@ lokasjon = {'fylke': [17]}
 
 Finn alle forekomster i hele landet:
 lokasjon = {'region': [1,2,3,4,5]}
+
+Om du synes advarselen om ugyldig SSL-sertifikat er irriterende: 
+Kommenter inn linje 8 i nvdb.py
 
 -----------------------------------------------------------------------------
 

--- a/nvdb.py
+++ b/nvdb.py
@@ -4,6 +4,9 @@ import json
 import requests
 import csv
 
+# Uncomment to silent those unverified https-request warnings
+requests.packages.urllib3.disable_warnings() 
+
 class Objekttyper:
     """Klasse som håndterer en liste med objekttyper:
     https://www.vegvesen.no/nvdb/api/dokumentasjon/datakatalog

--- a/nvdb.py
+++ b/nvdb.py
@@ -5,7 +5,7 @@ import requests
 import csv
 
 # Uncomment to silent those unverified https-request warnings
-requests.packages.urllib3.disable_warnings() 
+# requests.packages.urllib3.disable_warnings() 
 
 class Objekttyper:
     """Klasse som håndterer en liste med objekttyper:

--- a/tunneler_med_trafikkmengde.py
+++ b/tunneler_med_trafikkmengde.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+import pdb
+import logging
+from nvdb import query
+from nvdb import query_search
+from nvdb import csv_skriv
+from nvdb import Objekt
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+requests_log = logging.getLogger("requests")
+requests_log.setLevel(logging.WARNING)
+
+objekttyper = [{'id': 67, 'antall': 10000}]
+lokasjon = {'fylke': [3]}
+alletunnellop = query_search(objekttyper, lokasjon)
+
+csv_list = []
+
+tunnellop_nr = 0
+for tunnellop in alletunnellop.objekter():
+
+    tunnellop_nr += 1
+    logger.info('Bearbeider tunnelløp %s av %s' % (tunnellop_nr, alletunnellop.antall))
+    tunnellop = Objekt(tunnellop)
+    aadt = []
+    hgv = []
+    aar = []
+    veglenker = []
+    tunnel = ''
+    trafikkmengdeID = []
+
+    try:
+        tunnellop.assosiasjoner(581)
+    except KeyError:
+        logger.warning('tunnellop (# %s) har ingen mor-tunnel' % tunnellop.id)
+    else:
+        for i in tunnellop.assosiasjoner(581):
+            try:
+                tunnel = Objekt(query(i['relasjon']['uri']))
+            except Exception, e:
+                logger.error('Tunnellop (# %s) har referanse til tunnel som '
+                             'ikke er tilgjengelig: %s' % (tunnellop.id, e))
+            else:
+                pass
+                #row['lengde'] += tunnellop.lengde()
+                    
+        if tunnellop.veglenker() not in veglenker:
+            veglenker += tunnellop.veglenker()
+        
+        if not tunnel: 
+            logger.warning('Tunnelløpå (# %s) har ingen morobjekt-tunneller' % tunnellop.id) 
+            
+    if veglenker:
+        objekttyper = [{
+            'id': 540, 
+            'antall': 10000
+        }]
+        lokasjon = {'veglenker': veglenker}
+        trafikkmengder = query_search(objekttyper, lokasjon)
+            
+        if trafikkmengder.antall == 0:
+            logger.warning('Tunnelløp (# %s) har ingen trafikkmengdedata' % tunnellop.id) 
+        else: 
+            
+            for trafikkmengde in trafikkmengder.objekter():
+                trafikkmengde = Objekt(trafikkmengde)
+                aadt.append( str(trafikkmengde.egenskap(4623, verdi=0))) 
+                hgv.append( str(trafikkmengde.egenskap(4624, verdi=0))) 
+                aar.append( str(trafikkmengde.egenskap(4621, verdi=0))) 
+                trafikkmengdeID.append( str( trafikkmengde.id) )
+                
+        if trafikkmengder.antall > 1: 
+            logger.warning('Tunnelløp (# %s) har mer enn ett trafikkmengdeobjekt' % tunnellop.id) 
+        
+    else:
+        logger.warning('tunnellop (# %s) har ingen veglenker' % tunnellop.id)
+                
+    try:
+        tunnelnavn = tunnel.egenskap(5225)
+        skiltet_lengde = tunnel.egenskap(8945)
+        parallelle_lop = tunnel.egenskap(3947)
+    except KeyError:
+        logger.error('Tunnel (# %s) har ingen egenskaper' % tunnel.id)
+        skiltetlengde = None
+        tunnelnavn = None
+        antlop = None
+    
+    fylke = tunnellop.lokasjon('fylke')
+    kommune = tunnellop.lokasjon('kommune')
+    tunnellopNavn = tunnellop.egenskap(1081, verdi=None)
+    lengde = tunnellop.lengde()
+    tunnellopID = tunnellop.id
+    trafikkmengdeID = ",".join(trafikkmengdeID)
+    aadt = ",".join( aadt) 
+    hgv = ",".join( aar) 
+    aar = ",".join( aar) 
+
+    csv_row = [
+        tunnelnavn, tunnellopNavn, tunnellopID, fylke, kommune, skiltet_lengde, lengde, 
+        parallelle_lop, aadt, hgv, aar, trafikkmengdeID
+    ]
+    csv_list.append(csv_row)
+    
+csv_header = [
+    u'Tunnelnavn', u'Tunnelløp navn', u'Tunnelløp ID', u'Fylke', u'Kommune', u'Skiltet lengde tunnel', u'Lengde tunnelløp', 
+    u'Antall parallelle hovedløp', 'AADT', u'Andel tunge kjøretøy', u'Gjelder for år', u'Trafikkmengde ID'
+] 
+csv_list.insert(0, csv_header)
+
+csv_skriv('tunneler_med_trafikkmengde.csv', csv_list)


### PR DESCRIPTION
Nytt script tunneler_med_trafikkmengde.py sterkt inspirert av tunneler_med_trafikkmengde.py. 

Henter tunnelløp og tilhørende mor-tunneller, samt trafikkmengde per veglenke for tunnelløpet. 

Ved mer enn ett trafikkmengdeobjekt (per tunnelløp) lages en kommaseparert liste med dataverdier. 

ID til tunnelløp og trafikkmengde logges også. 
